### PR TITLE
change import location of ws_

### DIFF
--- a/app/partials/py/routing.py
+++ b/app/partials/py/routing.py
@@ -1,5 +1,5 @@
 from channels.routing import route
-from encode_api.consumers import ws_message, ws_job_connect, ws_disconnect
+from .consumers import ws_message, ws_job_connect, ws_disconnect
 
 channel_routing = [
     route("websocket.connect", ws_job_connect, path=r"^/ws/(?P<group_id>[a-zA-Z0-9_-]+)/$"),  # noqa


### PR DESCRIPTION
When download a Project generated from http://mmcardle.github.io/django_builder/,
install requirements with "pip install -r requirements.txt", migrate db, then runserver,
an exception occur, saying: "No module named encode_api.consumers"